### PR TITLE
Prioritize CommonJS bundle if required

### DIFF
--- a/packages/sign/package.json
+++ b/packages/sign/package.json
@@ -21,9 +21,9 @@
     }
   },
   "exports": {
+    "require": "./dist/index.cjs",
     "node": "./dist/index.mjs",
     "import": "./dist/index.esm.js",
-    "require": "./dist/index.cjs",
     "types": "./dist/index.d.ts"
   },
   "dependencies": {


### PR DESCRIPTION
Enable CommonJS-based Node.js codebases to adopt.