### PR TITLE
Add privateKey Length Check

### DIFF
--- a/packages/account-raw/index.ts
+++ b/packages/account-raw/index.ts
@@ -3,7 +3,7 @@ import * as secp from "@noble/secp256k1";
 
 /**
  * account-raw
- * 
+ *
  * Gets raw private key as input to create account.
  * if input private key is null, it randomly generates private key.
  */
@@ -13,6 +13,10 @@ export function createAccount(privateKey?: string | Uint8Array): Account {
     typeof privateKey === "string"
       ? secp.utils.hexToBytes(privateKey)
       : privateKey ?? secp.utils.randomPrivateKey();
+  if (privKey.length !== 32){
+    throw new Error(`Expected 32 bytes of private key, got ${privKey.length}`)
+  }
+
   return {
     VERSION: 0,
     getPublicKey(isCompressed) {


### PR DESCRIPTION
Some detection logic preventing 0x prefixed private key mistakenly used.