### PR TITLE
Seperate File/planetarium keystore related logic from main flow & deciper V3 on call time

### DIFF
--- a/packages/account-local/package.json
+++ b/packages/account-local/package.json
@@ -9,9 +9,18 @@
   "files": [
     "dist/**/*"
   ],
+  "imports": {
+    "#buffer": {
+      "node": "node:buffer",
+      "default": "buffer/"
+    }
+  },
   "dependencies": {
+    "@noble/hashes": "^1.1.3",
     "@noble/secp256k1": "^1.7.0",
-    "ethereumjs-wallet": "^1.0.2"
+    "buffer": "^6.0.3",
+    "ethereumjs-wallet": "^1.0.2",
+    "scrypt-js": "^3.0.1"
   },
   "devDependencies": {
     "@planetarium/sign": "workspace:^",

--- a/packages/account-local/util.ts
+++ b/packages/account-local/util.ts
@@ -49,3 +49,13 @@ export async function sanitizeKeypath(folder: string | undefined = KEYSTORE_PATH
   if (!fs.stat(folder)) throw new Error("This path does not exist");
   return folder;
 }
+
+export async function listKeystoreFiles(folder?: string): Promise<string[]> {
+  const list = (await fs.readdir(await sanitizeKeypath(folder)))
+    .map((f) => f.match(UTC_FILE_PATTERN)?.[0])
+    .filter((v): v is string => !!v);
+  if (list.length <= 0) {
+    throw new Error("No keys found in folder");
+  }
+  return list;
+}

--- a/packages/account-local/v3.ts
+++ b/packages/account-local/v3.ts
@@ -1,0 +1,108 @@
+import { syncScrypt } from "scrypt-js";
+import { keccak_256 } from "@noble/hashes/sha3";
+import { bytesToHex } from "@noble/hashes/utils";
+import * as crypto from "crypto";
+import Wallet from "ethereumjs-wallet";
+// code from https://github.com/ethereumjs/ethereumjs-wallet/blob/4cccc623f30839ceb53a007d5a0cce452a0dff88/src/index.ts#L662
+
+// https://github.com/ethereum/wiki/wiki/Web3-Secret-Storage-Definition
+interface V3Keystore {
+  crypto: {
+    cipher: string;
+    cipherparams: {
+      iv: string;
+    };
+    ciphertext: string;
+    kdf: string;
+    kdfparams: KDFParamsOut;
+    mac: string;
+  };
+  id: string;
+  version: number;
+}
+
+interface PBKDFParamsOut {
+  c: number;
+  dklen: number;
+  prf: string;
+  salt: string;
+}
+
+interface ScryptKDFParamsOut {
+  dklen: number;
+  n: number;
+  p: number;
+  r: number;
+  salt: string;
+}
+
+type KDFParamsOut = ScryptKDFParamsOut | PBKDFParamsOut;
+
+export function decipherV3(
+  input: string | V3Keystore,
+  password: string,
+  nonStrict = false
+): Wallet {
+  const json: V3Keystore =
+    typeof input === "object"
+      ? input
+      : JSON.parse(nonStrict ? input.toLowerCase() : input);
+
+  if (json.version !== 3) {
+    throw new Error("Not a V3 wallet");
+  }
+
+  let derivedKey: Uint8Array, kdfparams: any;
+  if (json.crypto.kdf === "scrypt") {
+    kdfparams = json.crypto.kdfparams;
+
+    // FIXME: support progress reporting callback
+    derivedKey = syncScrypt(
+      Buffer.from(password),
+      Buffer.from(kdfparams.salt, "hex"),
+      kdfparams.n,
+      kdfparams.r,
+      kdfparams.p,
+      kdfparams.dklen
+    );
+  } else if (json.crypto.kdf === "pbkdf2") {
+    kdfparams = json.crypto.kdfparams;
+
+    if (kdfparams.prf !== "hmac-sha256") {
+      throw new Error("Unsupported parameters to PBKDF2");
+    }
+
+    derivedKey = crypto.pbkdf2Sync(
+      Buffer.from(password),
+      Buffer.from(kdfparams.salt, "hex"),
+      kdfparams.c,
+      kdfparams.dklen,
+      "sha256"
+    );
+  } else {
+    throw new Error("Unsupported key derivation scheme");
+  }
+
+  const ciphertext = Buffer.from(json.crypto.ciphertext, "hex");
+  const mac = keccak_256(
+    Buffer.concat([Buffer.from(derivedKey.slice(16, 32)), ciphertext])
+  );
+  if (bytesToHex(mac) !== json.crypto.mac) {
+    throw new Error("Key derivation failed - possibly wrong passphrase");
+  }
+
+  const decipher = crypto.createDecipheriv(
+    json.crypto.cipher,
+    derivedKey.slice(0, 16),
+    Buffer.from(json.crypto.cipherparams.iv, "hex")
+  );
+  const seed = runCipherBuffer(decipher, ciphertext);
+  return new Wallet(seed);
+}
+
+function runCipherBuffer(
+  cipher: crypto.Cipher | crypto.Decipher,
+  data: Buffer
+): Buffer {
+  return Buffer.concat([cipher.update(data), cipher.final()]);
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -885,6 +885,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@noble/hashes@npm:^1.1.3":
+  version: 1.1.3
+  resolution: "@noble/hashes@npm:1.1.3"
+  checksum: a6f9783d2a33fc528c8709532b1c26cc3f5866f79c66256e881b28c61a1585be3899b008aa4e5e2b4e01b95c713722f52591cbb18ec51aa0ec63e7eaece1b89c
+  languageName: node
+  linkType: hard
+
 "@noble/secp256k1@npm:^1.7.0":
   version: 1.7.0
   resolution: "@noble/secp256k1@npm:1.7.0"
@@ -959,11 +966,14 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@planetarium/account-local@workspace:packages/account-local"
   dependencies:
+    "@noble/hashes": ^1.1.3
     "@noble/secp256k1": ^1.7.0
     "@planetarium/sign": "workspace:^"
     "@types/node": ^18.7.23
+    buffer: ^6.0.3
     ethereumjs-wallet: ^1.0.2
     nanobundle: ^0.0.28
+    scrypt-js: ^3.0.1
   peerDependencies:
     "@planetarium/sign": "workspace:^"
   languageName: unknown


### PR DESCRIPTION
This resolves #33 and #29.

- Move listKeystoreFiles based on filename-UUID to utils, and separate function call "getAccountFromFile" added for interoperability.
- Copied V3 parsing-deciper logic from [ethereumjs-wallet](https://github.com/ethereumjs/ethereumjs-wallet/blob/4cccc623f30839ceb53a007d5a0cce452a0dff88/src/index.ts) and make it synchronous so we call call decipher fucntion on call time of getPublicKey() and sign(). this arguably improves security by not storing the privkey in the whole lifecycle of the account instance.