### PR TITLE
Fix a crash from santizeKeypath()

### DIFF
--- a/packages/account-local/util.ts
+++ b/packages/account-local/util.ts
@@ -47,7 +47,7 @@ const KEYSTORE_PATH: {
 
 export function sanitizeKeypath(folder: string | undefined = KEYSTORE_PATH[process.platform]){
   if (typeof folder !== "string") throw new Error("Invalid path value");
-  if (!fs.stat(folder)) throw new Error("This path does not exist");
+  if (!fs.existsSync(folder)) throw new Error("This path does not exist");
   return folder;
 }
 


### PR DESCRIPTION
I guessed that `fs.existsSync()` was what we wanted. (`fs.stat()` requires a callback and causes an uncatchable exception when given path didn't exist)