### PR TITLE
Fix wrong existsSync and release account-local 0.0.35

### DIFF
--- a/packages/account-local/index.ts
+++ b/packages/account-local/index.ts
@@ -1,5 +1,5 @@
 import { Account } from "@planetarium/sign";
-import { sanitizeKeypath, listKeystoreFiles, UTC_FILE_PATTERN } from "./util";
+import { sanitizeKeypath, listKeystoreFiles, UTC_FILE_PATTERN, getDefaultKeystorePath } from "./util";
 import { decipherV3, V3Keystore, rawPrivateKeyToV3 } from "./v3";
 import fs from "fs/promises";
 import path from "path";
@@ -76,6 +76,7 @@ export {
   decipherV3,
   rawPrivateKeyToV3,
   sanitizeKeypath,
+  getDefaultKeystorePath,
   listKeystoreFiles,
   UTC_FILE_PATTERN,
   V3Keystore,

--- a/packages/account-local/package.json
+++ b/packages/account-local/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@planetarium/account-local",
-  "version": "0.0.32",
+  "version": "0.0.35",
   "license": "LGPL",
   "source": "index.ts",
   "module": "dist/index.mjs",

--- a/packages/account-local/package.json
+++ b/packages/account-local/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@planetarium/account-local",
-  "version": "0.0.35",
+  "version": "0.0.37",
   "license": "LGPL",
   "source": "index.ts",
   "module": "dist/index.mjs",

--- a/packages/account-local/util.ts
+++ b/packages/account-local/util.ts
@@ -1,6 +1,5 @@
 import { homedir } from "os";
-import { readdirSync } from "fs";
-import fs from "fs/promises";
+import { readdirSync, existsSync } from "fs";
 import path from "path";
 
 export const UTC_FILE_PATTERN =
@@ -47,7 +46,7 @@ const KEYSTORE_PATH: {
 
 export function sanitizeKeypath(folder: string | undefined = KEYSTORE_PATH[process.platform]){
   if (typeof folder !== "string") throw new Error("Invalid path value");
-  if (!fs.existsSync(folder)) throw new Error("This path does not exist");
+  if (!existsSync(folder)) throw new Error("This path does not exist");
   return folder;
 }
 

--- a/packages/account-local/util.ts
+++ b/packages/account-local/util.ts
@@ -44,7 +44,11 @@ const KEYSTORE_PATH: {
   haiku: undefined,
 };
 
-export function sanitizeKeypath(folder: string | undefined = KEYSTORE_PATH[process.platform]){
+export function getDefaultKeystorePath(platform: string) {
+  return KEYSTORE_PATH[platform];
+}
+
+export function sanitizeKeypath(folder: string | undefined = getDefaultKeystorePath(process.platform)){
   if (typeof folder !== "string") throw new Error("Invalid path value");
   if (!existsSync(folder)) throw new Error("This path does not exist");
   return folder;

--- a/packages/sign/package.json
+++ b/packages/sign/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@planetarium/sign",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "type": "module",
   "license": "LGPL",
   "source": "src/index.ts",

--- a/packages/sign/src/index.ts
+++ b/packages/sign/src/index.ts
@@ -67,7 +67,7 @@ export async function signTransaction(
 }
 
 export async function deriveAddress(account: Account) {
-  const publicKey = await account.getPublicKey();
+  const publicKey = await account.getPublicKey(false);
   return (
     "0x" + toChecksum(bytesToHex(keccak_256(publicKey.slice(1))).slice(-40))
   );


### PR DESCRIPTION
- This PR fixes a bug from #36 that `fs.existsSync` doesn't exist since `fs` wasn't `fs` module, but was `fs/promise`.
- 0.0.32, 0.0.33 and 0.0.34 have been deprecated due to the wrong publishing. 😢 

